### PR TITLE
Highlight brackets as rawstring delimiters.

### DIFF
--- a/syntax/cpp11_cbase.vim
+++ b/syntax/cpp11_cbase.vim
@@ -56,7 +56,7 @@ endif
 
 syn match	cppRawPrefix	display $\(L\|u8\|u\|U\)\?\zeR"[a-zA-Z0-9_{}[\]#<>%:;.?*+\-/^&|~!=,"']*($ nextgroup=cppRawStart
 syn match	cppRawStart	display contained $R"\ze[a-zA-Z0-9_{}[\]#<>%:;.?*+\-/^&|~!=,"']*($ nextgroup=cppRawString
-syn region      cppRawString	display contained matchgroup=cppRawDelimiter start=$\z([a-zA-Z0-9_{}[\]#<>%:;.?*+\-/^&|~!=,"']*\)\ze($ end=$)\zs\z1\ze"$ contains=@Spell nextgroup=cppRawEnd
+syn region      cppRawString	display contained matchgroup=cppRawDelimiter start=$\z([a-zA-Z0-9_{}[\]#<>%:;.?*+\-/^&|~!=,"']*\)($ end=$)\z1\ze"$ contains=@Spell nextgroup=cppRawEnd
 syn match	cppRawEnd	display contained +"+ nextgroup=cppTextSuffix
 
 syn match	cCharPrefixStrict display "\(L\|u8\|u\|U\)\?\ze'" nextgroup=cCharacter


### PR DESCRIPTION
Given this literal:

```cpp
u8R"verbatim(hello this is literal)verbatim"_suffix
```

The `()` brackets are highlighted the same as the literal contents. This was originally for consistency with e.g. `"a plain string literal"` where the delimiting quotes are highlighted the same as the literal contents.

This PR changes the brackets to be highlighted the same as the user-specified delimiter (i.e. `verbatim` in the example). This better sets apart the literal contents, which is especially helpful for raw string literals containing hard-to-read contents (e.g. lots of brackets). The other delimiting elements (i.e. `R"` at the start, `"` at the end) remain highlighted the same as the contents, as with plain string literals. A quick preview (with `set spell`):

![rawstring_lit](https://user-images.githubusercontent.com/5111293/30356141-ac074418-9837-11e7-9076-95022166bc3e.png)



